### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/LechevSpace/embedded-canvas/compare/v0.3.0...v0.3.1) - 2024-05-11
+
+### Added
+- *(release-plz)* config for replacing PR and issue `#..` with urls
+- *(ci)* dependabot.yml for outdated actions
+
+### Fixed
+- *(release-plz)* config - add commit_preprocessors
+- *(consts)* CCanvas - switched Width and Hight in pixels array
+
+### Other
+- Merge branch 'main' into dependabot/github_actions/actions/checkout-4
+- release-plz PR workflow
+- *(Cargo.toml)* Upgrade dependencies
+
 ### Added
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embedded-canvas"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-canvas"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Lechev.space <dev@lechev.space>", "Lachezar Lechev"]
 description = "Draw anything with ease on the Canvas before drawing it to your small hardware display"
 categories = ["embedded", "no-std"]


### PR DESCRIPTION
## 🤖 New release
* `embedded-canvas`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/LechevSpace/embedded-canvas/compare/v0.3.0...v0.3.1) - 2024-05-11

### Added
- *(release-plz)* config for replacing PR and issue `#..` with urls
- *(ci)* dependabot.yml for outdated actions

### Fixed
- *(release-plz)* config - add commit_preprocessors
- *(consts)* CCanvas - switched Width and Hight in pixels array

### Other
- Merge branch 'main' into dependabot/github_actions/actions/checkout-4
- release-plz PR workflow
- *(Cargo.toml)* Upgrade dependencies

### Added

### Changed

### Removed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).