### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/LechevSpace/embedded-canvas/compare/v0.3.1...v0.3.2) - 2025-08-25
+
+### Fixed
+
+- *(ci)* msrv workflow need to install SDL2
+
+### Other
+
+- *(deps)* bump actions/checkout from 4 to 5
+- Remove unnecessary trait bounds
+- Fix docs formatting to appease clippy
+- Derive Clone for Canvas<C>
+- *(msrv)* add independant msrv workflow
+- *(ci)* ci workflow - use rust-toolchain action and optimize the workflow
+
 ## [0.3.1](https://github.com/LechevSpace/embedded-canvas/compare/v0.3.0...v0.3.1) - 2024-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embedded-canvas"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-canvas"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Lechev.space <dev@lechev.space>", "Lachezar Lechev"]
 description = "Draw anything with ease on the Canvas before drawing it to your small hardware display"
 categories = ["embedded", "no-std"]


### PR DESCRIPTION



## 🤖 New release

* `embedded-canvas`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/LechevSpace/embedded-canvas/compare/v0.3.1...v0.3.2) - 2025-08-25

### Fixed

- *(ci)* msrv workflow need to install SDL2

### Other

- *(deps)* bump actions/checkout from 4 to 5
- Remove unnecessary trait bounds
- Fix docs formatting to appease clippy
- Derive Clone for Canvas<C>
- *(msrv)* add independant msrv workflow
- *(ci)* ci workflow - use rust-toolchain action and optimize the workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).