### PR TITLE
Remove unnecessary trait bounds

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -9,7 +9,7 @@ use crate::utils::center_offset;
 /// Draw on the [`Canvas`] using origin of [`Point::zero()`].
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
-pub struct Canvas<C: PixelColor> {
+pub struct Canvas<C> {
     /// The size of the [`Canvas`].
     pub canvas: Size,
     /// The pixels of the [`Canvas`].
@@ -54,7 +54,9 @@ impl<C: PixelColor> Canvas<C> {
     pub fn center(&self) -> Point {
         Point::zero() + center_offset(self.canvas)
     }
+}
 
+impl<C: PixelColor> Canvas<C> {
     /// Create a new cropped [`Canvas`].
     ///
     /// This method takes into account the top left [`Point`] of the `area`
@@ -110,7 +112,7 @@ impl<C: PixelColor> Canvas<C> {
     }
 }
 
-impl<C: PixelColor> OriginDimensions for Canvas<C> {
+impl<C> OriginDimensions for Canvas<C> {
     fn size(&self) -> Size {
         self.canvas
     }
@@ -138,7 +140,7 @@ impl<C: PixelColor> DrawTarget for Canvas<C> {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Debug, Clone)]
 
-pub struct CanvasAt<C: PixelColor> {
+pub struct CanvasAt<C> {
     /// The top left offset where the [`CanvasAt`] will be drawn to the display.
     pub top_left: Point,
     /// The size of the [`CanvasAt`].

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -18,16 +18,13 @@ use crate::utils::center_offset;
 /// should less than [`u32::MAX`] as [`Size`] uses [`u32`].
 ///
 /// [const_generics_rfc]: https://rust-lang.github.io/rfcs/2000-const-generics.html
-pub struct CCanvas<C: PixelColor, const W: usize, const H: usize> {
+pub struct CCanvas<C, const W: usize, const H: usize> {
     // we also store the size for working with embedded-graphics
     pub size: Size,
     pub pixels: [[Option<C>; H]; W],
 }
 
-impl<C, const W: usize, const H: usize> Default for CCanvas<C, W, H>
-where
-    C: PixelColor,
-{
+impl<C: Copy + PartialEq, const W: usize, const H: usize> Default for CCanvas<C, W, H> {
     fn default() -> Self {
         Self::new()
     }
@@ -35,7 +32,7 @@ where
 
 impl<C, const W: usize, const H: usize> CCanvas<C, W, H>
 where
-    C: PixelColor,
+    C: Copy + PartialEq,
 {
     /// Create a new blank [`CCanvas`].
     ///
@@ -82,7 +79,12 @@ where
     pub fn center(&self) -> Point {
         Point::zero() + center_offset(self.size)
     }
+}
 
+impl<C, const W: usize, const H: usize> CCanvas<C, W, H>
+where
+    C: PixelColor,
+{
     /// Create a new cropped [`CCanvas`].
     ///
     /// This method takes into account the top left [`Point`] of the `area`
@@ -144,7 +146,7 @@ where
     }
 }
 
-impl<C: PixelColor, const W: usize, const H: usize> OriginDimensions for CCanvas<C, W, H> {
+impl<C, const W: usize, const H: usize> OriginDimensions for CCanvas<C, W, H> {
     fn size(&self) -> Size {
         self.size
     }


### PR DESCRIPTION
Some trait bounds are put on Canvas and CCanvas unnecessarily. This causes code including canvas in it to be infected with trait bounds unnecessarily, and makes it harder to contain Canvas in other structs with generics.

In this PR, I removed all unnecessary trait bounds. This should have zero effect on functionality, as long as it compiles.